### PR TITLE
Drag color and release mouse outside closes picker

### DIFF
--- a/color-picker.js
+++ b/color-picker.js
@@ -392,7 +392,10 @@
                         hookFire('blur', color);
                     } else {
                         // Click outside the source or picker element to exit
-                        isVisible() && doExit();
+                        if (SVDragging || HDragging || ADragging) {
+                        } else {
+                            isVisible() && doExit();
+                        }
                     }
                 } else {
                     if (isSelf) {


### PR DESCRIPTION
If I press and drag color within bounds of color picker it stays open.

if I press and drag color and then release mouse outside of bounds of picker it closes, which is counter intuitive.

Color picker should track when I pressed initially, if it was inside picker, then releasing mouse outside of bounds should not cause picker to close. If I initially pressed outside of bounds and then released outside, it closes picker.

Edit: Pull request is just a dirty fix, if I add custom element (like input with color hex text), then it requires more logic to be coded. I hope you can make a nice solution to this, or provide this as an option to not brake previous behavior.